### PR TITLE
Fix CO2 ABC

### DIFF
--- a/CO2_ABC.ino
+++ b/CO2_ABC.ino
@@ -35,7 +35,10 @@ void processCO2() {
     //once the monitoring starts - rollover will not play
     startedCO2Monitoring = true;  
     processCO2SensorData();
-    co2OnOneHour();
+    if (!startedCO2Monitoring) {
+      storeCurrentCO2MaxMv();
+      startedCO2Monitoring = true;  
+    }
   }
   computeCO2PPM();
 
@@ -66,8 +69,12 @@ void computeCO2PPM() {
   sPPM = mv2ppm(getCO2MaxMv() - raCO2mv.getAverage());
 }
 
+void storeCurrentCO2MaxMv() {
+  EEPROM.put(EE_FLT_CURRENT_PERIOD_CO2_HIGHESTMV, currentCO2MaxMv);  
+}
+
 void co2OnOneHour() {
-  EEPROM.put(EE_FLT_CURRENT_PERIOD_CO2_HIGHESTMV, currentCO2MaxMv);
+  storeCurrentCO2MaxMv();
   if (eeAddHourAndReturn() == cfg_abc_resetHours) {
     for (byte i=0; i < 4; i++) EEPROM.put(EE_4B_HOUR + i, (byte)0);
     EEPROM.put(EE_FLT_PREV_PERIOD_CO2_HIGHESTMV, currentCO2MaxMv);

--- a/ESP8266.ino
+++ b/ESP8266.ino
@@ -113,7 +113,7 @@ int sendTsInt(int value) {
   
   esp << TS_GET << key << TS_FIELD << value << endl << endl;
  // if (!serialFind(OK, true, 6000)) return -3;
-  if (!serialFind("CLOSED", DEBUG, 6000)) return -4;
+  if (!serialFind("CLOSED", true, 6000)) return -4;
   return 1;
 }
 
@@ -139,7 +139,7 @@ void processSendData() {
 
   int res = sendToThingSpeak(sPPM);
   
-  //Serial << F("TS RES:") << res << endl;
+  Serial << F("TS RES:") << res << endl;
   espOFF();
   tmWifiSent = millis();
   


### PR DESCRIPTION
Hours were increased with each CO2 Processing iteration after the first
15 minutes were passed. Now it is switched, so that after the first 15
minutes, the Co2MaxMv is stored to EEProm to speedup initial startup.

ESP8266 - increased logging level, to trace easier connectivity issues
to TS
